### PR TITLE
fix: no source maps in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,9 @@
     "watch": "^1.0.2"
   },
   "scripts": {
-    "prepublishOnly": "yarn build # runs before publish",
+    "prepublishOnly": "yarn build:production # runs before publish",
     "build": "rm -rf dist && tsc --module CommonJS",
+    "build:production": "yarn build -p tsconfig.production.json",
     "build:watch": "rm -rf dist && tsc -w --module CommonJS",
     "tsc": "tsc -p . --noEmit && tsc -p ./src/__tests__",
     "test:browser": "yarn tsc && jest -c ./config/jest.config.js --env=jsdom",

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/alex-cory/use-http/issues/202

### Description

Currently, source maps are generated in the production build but they point to source files that don't exist in the distribution.

### Solution

I suggest to disable source maps generation during the production build.