### PR TITLE
Fixes/changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,21 +998,6 @@ Todos
   - [ ] show comparison with Apollo
   - [ ] figure out a good way to show side-by-side comparisons
   - [ ] show comparison with Axios
-- [ ] maybe add syntax for middle helpers for inline `headers` or `queries` like this:
-
-  ```jsx
-    const request = useFetch('https://example.com')
-
-    request
-      .headers({
-        auth: jwt      // this would inline add the `auth` header
-      })
-      .query({         // might have to use .params({ }) since we're using .query() for GraphQL
-        no: 'way'      // this would inline make the url: https://example.com?no=way
-      })
-      .get()
-  ```
-
 - [ ] potential option ideas
 
   ```jsx
@@ -1022,6 +1007,14 @@ Todos
       // to overwrite those of `useFetch` for
       // `useMutation` and `useQuery`
     },
+    responseType: 'json', // similar to axios
+    // OR can be an array. We will try to get the `data`
+    // by attempting to extract it via these body interface
+    // methods, one by one in this order
+    responseType: ['json', 'text', 'blob', 'formData', 'arrayBuffer'],
+    // ALSO, maybe there's a way to guess the proper `body interface method` for the correct response content-type.
+    // here's a stackoverflow with someone who's tried: https://bit.ly/2X8iaVG
+
     // Allows you to pass in your own cache to useFetch
     // This is controversial though because `cache` is an option in the requestInit
     // and it's value is a string. See: https://developer.mozilla.org/en-US/docs/Web/API/Request/cache

--- a/README.md
+++ b/README.md
@@ -964,6 +964,7 @@ Todos
   - .json() ['application/json']
   - .text() ['text/plain']
   - .blob() ['image/png', 'application/octet-stream']
+- [ ] is making a [gitpod](https://www.gitpod.io/docs/configuration/) useful here? 🤔
 - [ ] suspense
   - [ ] triggering it from outside the `<Suspense />` component.
     - add `.read()` to `request`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/alex-cory/use-http.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "dependencies": {
     "use-ssr": "^1.0.22"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-http",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "homepage": "http://use-http.com",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "https://github.com/alex-cory/use-http.git"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "dependencies": {
     "use-ssr": "^1.0.22"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-http",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "homepage": "http://use-http.com",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/__tests__/doFetchArgs.test.tsx
+++ b/src/__tests__/doFetchArgs.test.tsx
@@ -1,6 +1,6 @@
 import doFetchArgs from '../doFetchArgs'
 import { HTTPMethod } from '../types'
-import { defaults } from '../useFetchArgs'
+import defaults from '../defaults'
 import useCache from '../useCache'
 
 describe('doFetchArgs: general usages', (): void => {

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -9,6 +9,7 @@ import { toCamel } from 'convert-keys'
 import { renderHook, act } from '@testing-library/react-hooks'
 import mockConsole from 'jest-mock-console'
 import * as mockdate from 'mockdate'
+import defaults from '../defaults'
 
 import { Res, Options, CachePolicies } from '../types'
 import { emptyCustomResponse, sleep, makeError } from '../utils'
@@ -92,9 +93,9 @@ describe('useFetch - BROWSER - basic functionality', (): void => {
       var formData = new FormData()
       formData.append('username', 'AlexCory')
       await result.current.post(formData)
-      const options = fetch.mock.calls[0][1] || {}
+      const options = fetch.mock.calls[0][1] || { headers: {} }
       expect(options.method).toBe('POST')
-      expect(options.headers).toBeUndefined()
+      expect('Content-Type' in (options as any).headers).toBe(false)
     })
   })
 })
@@ -591,8 +592,9 @@ describe('useFetch - BROWSER - Overwrite Global Options set in Provider', (): vo
   })
 
   it('should only add Content-Type: application/json for POST and PUT by default', async (): Promise<void> => {
-    const expectedHeadersGET = providerHeaders
+    const expectedHeadersGET = { ...defaults.headers, ...providerHeaders }
     const expectedHeadersPOSTandPUT = {
+      ...defaults.headers,
       ...providerHeaders,
       'Content-Type': 'application/json'
     }
@@ -613,7 +615,10 @@ describe('useFetch - BROWSER - Overwrite Global Options set in Provider', (): vo
   })
 
   it('should have the correct headers set in the options set in the Provider', async (): Promise<void> => {
-    const expectedHeaders = providerHeaders
+    const expectedHeaders = {
+      ...defaults.headers,
+      ...providerHeaders
+    }
     const { result } = renderHook(
       () => useFetch(),
       { wrapper }
@@ -625,7 +630,7 @@ describe('useFetch - BROWSER - Overwrite Global Options set in Provider', (): vo
   })
 
   it('should overwrite url and options set in the Provider', async (): Promise<void> => {
-    const expectedHeaders = undefined
+    const expectedHeaders = defaults.headers
     const expectedURL = 'https://example2.com'
     const { result, waitForNextUpdate } = renderHook(
       () => useFetch(expectedURL, globalOptions => {
@@ -644,7 +649,7 @@ describe('useFetch - BROWSER - Overwrite Global Options set in Provider', (): vo
   })
 
   it('should overwrite options set in the Provider', async (): Promise<void> => {
-    const expectedHeaders = undefined
+    const expectedHeaders = defaults.headers
     const { result, waitForNextUpdate } = renderHook(
       () => useFetch(globalOptions => {
         // TODO: fix the generics here so it knows when a header

--- a/src/__tests__/useFetchArgs.test.tsx
+++ b/src/__tests__/useFetchArgs.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
-import useFetchArgs, { useFetchArgsDefaults } from '../useFetchArgs'
+import useFetchArgs from '../useFetchArgs'
+import defaults, { useFetchArgsDefaults } from '../defaults'
 import React, { ReactElement, ReactNode } from 'react'
 import { Provider } from '..'
 
@@ -183,7 +184,11 @@ describe('useFetchArgs: general usages', (): void => {
         url: 'https://example.com'
       },
       requestInit: {
-        ...options
+        ...options,
+        headers: {
+          ...defaults.headers,
+          ...options.headers
+        }
       }
     })
   })
@@ -201,7 +206,10 @@ describe('useFetchArgs: general usages', (): void => {
         url: 'http://localhost'
       },
       requestInit: {
-        ...options
+        headers: {
+          ...defaults.headers,
+          ...options.headers
+        }
       }
     })
   })
@@ -231,7 +239,11 @@ describe('useFetchArgs: general usages', (): void => {
         url: 'http://localhost'
       },
       requestInit: {
-        ...overwriteProviderOptions
+        ...overwriteProviderOptions,
+        headers: {
+          ...defaults.headers,
+          ...overwriteProviderOptions.headers
+        }
       }
     })
   })

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,38 @@
+import { Flatten, CachePolicies, UseFetchArgsReturn } from './types'
+import { isObject } from './utils'
+
+
+export const useFetchArgsDefaults: UseFetchArgsReturn = {
+  customOptions: {
+    cacheLife: 0,
+    cachePolicy: CachePolicies.CACHE_FIRST,
+    interceptors: {},
+    onAbort: () => { /* do nothing */ },
+    onNewData: (currData: any, newData: any) => newData,
+    onTimeout: () => { /* do nothing */ },
+    path: '',
+    perPage: 0,
+    persist: false,
+    retries: 0,
+    retryDelay: 1000,
+    retryOn: [],
+    suspense: false,
+    timeout: 0,
+    url: '',
+  },
+  requestInit: {
+    headers: {
+      Accept: 'application/json, text/plain, */*'
+    }
+  },
+  defaults: {
+    data: undefined,
+    loading: false
+  },
+  dependencies: undefined
+}
+
+export default Object.entries(useFetchArgsDefaults).reduce((acc, [key, value]) => {
+  if (isObject(value)) return { ...acc, ...value }
+  return { ...acc, [key]: value }
+}, {} as Flatten<UseFetchArgsReturn>)

--- a/src/doFetchArgs.ts
+++ b/src/doFetchArgs.ts
@@ -44,8 +44,8 @@ export default async function doFetchArgs<TData = any>(
       ((bodyAs2ndParam as any) instanceof FormData ||
         (bodyAs2ndParam as any) instanceof URLSearchParams)
     ) return bodyAs2ndParam as any
-    if (isBodyObject(bodyAs2ndParam)) return JSON.stringify(bodyAs2ndParam)
-    if (isBodyObject(initialOptions.body)) return JSON.stringify(initialOptions.body)
+    if (isBodyObject(bodyAs2ndParam) || isString(bodyAs2ndParam)) return JSON.stringify(bodyAs2ndParam)
+    if (isBodyObject(initialOptions.body) || isString(bodyAs2ndParam)) return JSON.stringify(initialOptions.body)
     return null
   })()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,32 @@ export type OverwriteGlobalOptions = (options: Options) => Options
 export type RetryOn = (<TData = any>({ attempt, error, response }: { attempt: number, error: Error, response: Res<TData> | null }) => boolean) | number[]
 export type RetryDelay = (<TData = any>({ attempt, error, response }: { attempt: number, error: Error, response: Res<TData> | null }) => number) | number
 
+export type UseFetchArgsReturn = {
+  customOptions: {
+    cacheLife: number
+    cachePolicy: CachePolicies
+    interceptors: Interceptors
+    onAbort: () => void
+    onNewData: (currData: any, newData: any) => any
+    onTimeout: () => void
+    path: string
+    perPage: number
+    persist: boolean
+    retries: number
+    retryDelay: RetryDelay
+    retryOn: RetryOn | undefined
+    suspense: boolean
+    timeout: number
+    url: string
+  }
+  requestInit: RequestInit
+  defaults: {
+    loading: boolean
+    data?: any
+  }
+  dependencies?: any[]
+}
+
 /**
  * Helpers
  */

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -88,8 +88,9 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
       if (response.isCached && cachePolicy === CACHE_FIRST) {
         try {
           res.current = response.cached as Res<TData>
-          res.current.data = await tryGetData(response.cached, defaults.data)
-          data.current = res.current.data as TData
+          const d = await tryGetData(response.cached, defaults.data)
+          res.current.data = d
+          data.current = d
           if (!suspense && mounted.current) forceUpdate()
           return data.current
         } catch (err) {
@@ -207,11 +208,11 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
   const post = useCallback(makeFetch(HTTPMethod.POST), [makeFetch])
   const del = useCallback(makeFetch(HTTPMethod.DELETE), [makeFetch])
 
-  const request: Req<TData> = {
-    get: useCallback(makeFetch(HTTPMethod.GET), [makeFetch]),
+  const request: Req<TData> = useMemo(() => ({
+    get: makeFetch(HTTPMethod.GET),
     post,
-    patch: useCallback(makeFetch(HTTPMethod.PATCH), [makeFetch]),
-    put: useCallback(makeFetch(HTTPMethod.PUT), [makeFetch]),
+    patch: makeFetch(HTTPMethod.PATCH),
+    put: makeFetch(HTTPMethod.PUT),
     del,
     delete: del,
     abort: () => controller.current && controller.current.abort(),
@@ -221,7 +222,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     error: error.current,
     data: data.current,
     cache
-  }
+  }), [])
 
   const response = useMemo(() => toResponseObject<TData>(res, data), [])
 

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -64,10 +64,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
 
   const makeFetch = useDeepCallback((method: HTTPMethod): FetchData => {
 
-    const doFetch = async (
-      routeOrBody?: RouteOrBody,
-      body?: Body
-    ): Promise<any> => {
+    const doFetch = async (routeOrBody?: RouteOrBody, body?: Body): Promise<any> => {
       if (isServer) return // for now, we don't do anything on the server
       controller.current = new AbortController()
       controller.current.signal.onabort = onAbort

--- a/src/useFetchArgs.ts
+++ b/src/useFetchArgs.ts
@@ -1,64 +1,9 @@
-import { OptionsMaybeURL, NoUrlOptions, Flatten, CachePolicies, Interceptors, OverwriteGlobalOptions, Options, RetryOn, RetryDelay } from './types'
+import { OptionsMaybeURL, NoUrlOptions, CachePolicies, Interceptors, OverwriteGlobalOptions, Options, RetryOn, RetryDelay, UseFetchArgsReturn } from './types'
 import { isString, isObject, invariant, pullOutRequestInit, isFunction, isPositiveNumber } from './utils'
 import { useContext, useMemo } from 'react'
 import FetchContext from './FetchContext'
+import defaults from './defaults'
 
-type UseFetchArgsReturn = {
-  customOptions: {
-    cacheLife: number
-    cachePolicy: CachePolicies
-    interceptors: Interceptors
-    onAbort: () => void
-    onNewData: (currData: any, newData: any) => any
-    onTimeout: () => void
-    path: string
-    perPage: number
-    persist: boolean
-    retries: number
-    retryDelay: RetryDelay
-    retryOn: RetryOn | undefined
-    suspense: boolean
-    timeout: number
-    url: string
-  }
-  requestInit: RequestInit
-  defaults: {
-    loading: boolean
-    data?: any
-  }
-  dependencies?: any[]
-}
-
-export const useFetchArgsDefaults: UseFetchArgsReturn = {
-  customOptions: {
-    cacheLife: 0,
-    cachePolicy: CachePolicies.CACHE_FIRST,
-    interceptors: {},
-    onAbort: () => { /* do nothing */ },
-    onNewData: (currData: any, newData: any) => newData,
-    onTimeout: () => { /* do nothing */ },
-    path: '',
-    perPage: 0,
-    persist: false,
-    retries: 0,
-    retryDelay: 1000,
-    retryOn: [],
-    suspense: false,
-    timeout: 0,
-    url: '',
-  },
-  requestInit: { headers: {} },
-  defaults: {
-    data: undefined,
-    loading: false
-  },
-  dependencies: undefined
-}
-
-export const defaults = Object.entries(useFetchArgsDefaults).reduce((acc, [key, value]) => {
-  if (isObject(value)) return { ...acc, ...value }
-  return { ...acc, [key]: value }
-}, {} as Flatten<UseFetchArgsReturn>)
 
 const useField = <DV = any>(
   field: keyof OptionsMaybeURL | keyof NoUrlOptions,
@@ -171,6 +116,7 @@ export default function useFetchArgs(
       ...contextRequestInit,
       ...requestInit,
       headers: {
+        ...defaults.headers,
         ...contextRequestInit.headers,
         ...requestInit.headers
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,7 +155,7 @@ export const tryGetData = async (res: Response | undefined, defaultData: any) =>
       data = (await response.text()) as any // FIXME: should not be `any` type
     } catch (er) {}
   }
-  return (defaultData && isEmpty(data)) ? defaultData : data
+  return !isEmpty(defaultData) && isEmpty(data) ? defaultData : data
 }
 
 /**


### PR DESCRIPTION
1. moved default values to `defaults.ts`
2. added default `Accept` header. Following `axios` here
3. fixed https://github.com/ava/use-http/issues/232 `request.post('/route', 'string body')`
4. fixed https://github.com/ava/use-http/issues/211 `Promise.all` should work
5. when using dependency arrays, `[request]` will work now, and `[request.get]` should work
6. when using dependency arrays, `[response]` must be used, `[response.ok]` will cause extra rerenders