### PR TITLE
Scalable interceptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-http",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://use-http.com",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-http",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://use-http.com",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/__tests__/doFetchArgs.test.tsx
+++ b/src/__tests__/doFetchArgs.test.tsx
@@ -96,7 +96,7 @@ describe('doFetchArgs: general usages', (): void => {
       cachePolicy: defaults.cachePolicy
     })
     const interceptors = {
-      request(options: any) {
+      async request({ options }: { options: any }) {
         options.headers.Authorization = 'Bearer test'
         return options
       }

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -521,7 +521,7 @@ describe('useFetch - BROWSER - interceptors', (): void => {
   const wrapper = ({ children }: { children?: ReactNode }): ReactElement => {
     const options: Options = {
       interceptors: {
-        request: async (opts, url, path, route) => {
+        request: async ({ options: opts, url, path, route }) => {
           if (path === '/path') {
             opts.data = 'path'
           }
@@ -533,7 +533,7 @@ describe('useFetch - BROWSER - interceptors', (): void => {
           }
           return opts
         },
-        async response(res) {
+        async response({ response: res }) {
           if (res.data) res.data = toCamel(res.data)
           return res
         }
@@ -609,11 +609,11 @@ describe('useFetch - BROWSER - interceptors', (): void => {
     const { result, waitForNextUpdate } = renderHook(
       () => useFetch('url', {
         interceptors: {
-          async request(options) {
+          async request({ options }) {
             requestCalled++
             return options
           },
-          async response(response) {
+          async response({ response }) {
             responseCalled++
             return response
           }
@@ -1030,9 +1030,9 @@ describe('useFetch - BROWSER - errors', (): void => {
   const wrapperCustomError = ({ children }: { children?: ReactNode }): ReactElement => {
     const options = {
       interceptors: {
-        async response(res: Res<any>): Promise<Res<any>> {
-          if (!res.ok) throw expectedError
-          return res
+        async response<TData = any>({ response }: { response: Res<TData> }): Promise<Res<TData>> {
+          if (!response.ok) throw expectedError
+          return response
         }
       },
       cachePolicy: NO_CACHE

--- a/src/doFetchArgs.ts
+++ b/src/doFetchArgs.ts
@@ -81,7 +81,7 @@ export default async function doFetchArgs<TData = any>(
     if (body !== null) opts.body = body
 
     if (requestInterceptor) {
-      const interceptor = await requestInterceptor(opts, initialURL, path, route)
+      const interceptor = await requestInterceptor({ options: opts, url: initialURL, path, route })
       return interceptor as any
     }
     return opts

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,9 +158,9 @@ export type UseFetchObjectReturn<TData> = ReqBase<TData> &
 export type UseFetch<TData> = UseFetchArrayReturn<TData> &
   UseFetchObjectReturn<TData>
 
-export type Interceptors = {
-  request?: (options: Options, url: string, path: string, route: string) => Promise<Options> | Options
-  response?: (response: Res<any>) => Promise<Res<any>>
+export type Interceptors<TData = any> = {
+  request?: ({ options, url, path, route }: { options: Options, url: string, path: string, route: string }) => Promise<Options> | Options
+  response?: ({ response }: { response: Res<TData> }) => Promise<Res<TData>>
 }
 
 // this also holds the response keys. It mimics js Map

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -96,7 +96,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
           res.current = response.cached as Res<TData>
           const theData = await tryGetData(response.cached, defaults.data)
           res.current.data = theData
-          res.current = interceptors.response ? await interceptors.response(res.current) : res.current
+          res.current = interceptors.response ? await interceptors.response({ response: res.current }) : res.current
           invariant('data' in res.current, 'You must have `data` field on the Response returned from your `interceptors.response`')
           data.current = res.current.data as TData
           if (!suspense && mounted.current) forceUpdate()
@@ -128,7 +128,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
         newData = await tryGetData(newRes, defaults.data)
         res.current.data = onNewData(data.current, newData)
 
-        res.current = interceptors.response ? await interceptors.response(res.current) : res.current
+        res.current = interceptors.response ? await interceptors.response({ response: res.current }) : res.current
         invariant('data' in res.current, 'You must have `data` field on the Response returned from your `interceptors.response`')
         data.current = res.current.data as TData
 


### PR DESCRIPTION
🚨🚨THIS PR CONTAINS BREAKING CHANGES!!! 🚨🚨
Due potential future scalability issues such as adding new items to pass to the interceptors, we're changing it to an object destructuring syntax instead of multiple arguments.
```js
useFetch({
  interceptors: {
    request: async (options, url, path, route) => {},
    response: async (response) => {}
  }
}
```
will now be
```js
useFetch({
  interceptors: {
    request: async ({ options, url, path, route }) => {}, // <- notice object destructuring
    response: async ({ response }) => {} // <- notice object destructuring
  }
}
```
This provides a few benefits.
1. we can now add new options to these callbacks without having breaking changes
2. we can pull out these options in whatever order so we don't have unused variables

For example, let's say in the future we want to do
```js
useFetch({
  interceptors: {
    request: async ({ options, route, attempt }) => {
      // now we can add a new field `attempt`
      // and we can just grab `route` without `url` and `path`
    },
    response: async ({ response, attempt }) => {
      // now we can add a new field `attempt`
    }
  }
}
```