### PR TITLE
Always parse and return data

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,7 +149,7 @@ export const tryGetData = async (res: Response | undefined, defaultData: any, re
   if (typeof responseType === 'undefined') throw Error('responseType cannot be undefined... 😵')
   const types = (Array.isArray(responseType) ? responseType : [responseType]) as ResponseType
   if (types[0] == null) throw Error('could not parse data from response 😵')
-  const data = res.ok ? await tryRetry(res, types) : undefined
+  const data = tryRetry(res, types)
   return !isEmpty(defaultData) && isEmpty(data) ? defaultData : data
 }
 
@@ -271,5 +271,5 @@ export const addSlash = (input?: string, url?: string) => {
   }
   if (url.endsWith('/') && input.startsWith('/')) return input.substr(1)
   if (!url.endsWith('/') && !input.startsWith('/') && !input.startsWith('?')) return `/${input}`
-  return input 
+  return input
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,7 +149,7 @@ export const tryGetData = async (res: Response | undefined, defaultData: any, re
   if (typeof responseType === 'undefined') throw Error('responseType cannot be undefined... 😵')
   const types = (Array.isArray(responseType) ? responseType : [responseType]) as ResponseType
   if (types[0] == null) throw Error('could not parse data from response 😵')
-  const data = tryRetry(res, types)
+  const data = await tryRetry(res, types)
   return !isEmpty(defaultData) && isEmpty(data) ? defaultData : data
 }
 


### PR DESCRIPTION
Gives access to response data even when response.ok is false. Allows for more customization based on returned data and saves having to parse data on errors.

Fixes #248