### PR TITLE
Move utility types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "urs": "^0.0.4",
-    "use-ssr": "^1.0.22"
+    "use-ssr": "^1.0.22",
+    "utility-types": "^3.10.0"
   },
   "peerDependencies": {
     "react": "^16.13.1",
@@ -49,7 +50,6 @@
     "react-test-renderer": "^16.13.1",
     "ts-jest": "^25.3.0",
     "typescript": "^3.8.3",
-    "utility-types": "^3.10.0",
     "watch": "^1.0.2"
   },
   "scripts": {


### PR DESCRIPTION
Since they are needed in production.

Resolves https://github.com/ava/use-http/issues/259

Possibly needs updating README - https://github.com/ava/use-http#features?