### PR TITLE
Fix link to fetch policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ This is exactly what you would pass to the normal js `fetch`, with a little extr
 | Option                | Description                                                               |  Default     |
 | --------------------- | --------------------------------------------------------------------------|------------- |
 | `cacheLife` | After a successful cache update, that cache data will become stale after this duration       | `0` |
-| `cachePolicy` | These will be the same ones as Apollo's [fetch policies](https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy). Possible values are `cache-and-network`, `network-only`, `cache-only`, `no-cache`, `cache-first`. Currently only supports **`cache-first`**  or **`no-cache`**      | `cache-first` |
+| `cachePolicy` | These will be the same ones as Apollo's [fetch policies](https://www.apollographql.com/docs/react/api/react/hoc/#optionsfetchpolicy). Possible values are `cache-and-network`, `network-only`, `cache-only`, `no-cache`, `cache-first`. Currently only supports **`cache-first`**  or **`no-cache`**      | `cache-first` |
 | `data` | Allows you to set a default value for `data`       | `undefined` |
 | `interceptors.request` | Allows you to do something before an http request is sent out. Useful for authentication if you need to refresh tokens a lot.  | `undefined` |
 | `interceptors.response` | Allows you to do something after an http response is recieved. Useful for something like camelCasing the keys of the response.  | `undefined` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -734,7 +734,7 @@ This is exactly what you would pass to the normal js `fetch`, with a little extr
 | Option                | Description                                                               |  Default     |
 | --------------------- | --------------------------------------------------------------------------|------------- |
 | `cacheLife` | After a successful cache update, that cache data will become stale after this duration       | `0` |
-| `cachePolicy` | These will be the same ones as Apollo's [fetch policies](https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy). Possible values are `cache-and-network`, `network-only`, `cache-only`, `no-cache`, `cache-first`. Currently only supports **`cache-first`**  or **`no-cache`**      | `cache-first` |
+| `cachePolicy` | These will be the same ones as Apollo's [fetch policies](https://www.apollographql.com/docs/react/api/react/hoc/#optionsfetchpolicy). Possible values are `cache-and-network`, `network-only`, `cache-only`, `no-cache`, `cache-first`. Currently only supports **`cache-first`**  or **`no-cache`**      | `cache-first` |
 | `data` | Allows you to set a default value for `data`       | `undefined` |
 | `interceptors.request` | Allows you to do something before an http request is sent out. Useful for authentication if you need to refresh tokens a lot.  | `undefined` |
 | `interceptors.response` | Allows you to do something after an http response is recieved. Useful for something like camelCasing the keys of the response.  | `undefined` |

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export enum HTTPMethod {
   PUT = 'PUT',
 }
 
-// https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy
+// https://www.apollographql.com/docs/react/api/react/hoc/#optionsfetchpolicy
 export enum CachePolicies {
   /**
    * This is the default value where we always try reading data


### PR DESCRIPTION
A tiny change.

The old URL - which is now gone:

* https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy

The new URL - I checked with Wayback Machine that it points to the same section:

* https://www.apollographql.com/docs/react/api/react/hoc/#optionsfetchpolicy