### PR TITLE
feat: Forward the original error

### DIFF
--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -1084,6 +1084,23 @@ describe('useFetch - BROWSER - errors', (): void => {
     expect(result.current.data).toEqual([])
   })
 
+  it('should set the `error` with custom errors', async (): Promise<void> => {
+    const customError = { id: 'Custom Error'}
+    fetch.resetMocks()
+    fetch.mockResponse(() => Promise.reject(customError))
+    const { result } = renderHook(
+      () => useFetch('https://example.com', {
+        data: [],
+        cachePolicy: NO_CACHE
+      })
+    )
+    expect(result.current.data).toEqual([])
+    expect(result.current.loading).toBe(false)
+    await act(result.current.get)
+    expect(result.current.error).toEqual(customError)
+    expect(result.current.data).toEqual([])
+  })
+
   it('should reset the error after each call', async (): Promise<void> => {
     fetch.resetMocks()
     fetch.mockRejectOnce(expectedError)

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -84,7 +84,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
         body,
         interceptors.request
       )
-      
+
       error.current = undefined
 
       // don't perform the request if there is no more data to fetch (pagination)
@@ -151,8 +151,10 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
           const theData = await retry(opts, routeOrBody, body)
           return theData
         }
-        if (err.name !== 'AbortError') error.current = makeError(err.name, err.message)
- 
+        if (err.name !== 'AbortError') {
+          error.current = err
+        }
+
       } finally {
         timedout.current = false
         if (timer) clearTimeout(timer)


### PR DESCRIPTION
On a project i'm working on I have interceptors that can throw custom errors. Internally use-http rewrite error and every detail about the cause of the error is lost).

Here is an example of use case

```js
  const useHttpOptions = {
    interceptors: {
      response: async ({ response }) => {
        if (!hasErrorCode(response)) {
          return response
        }
        throw new ApiError({
          errorCode: response.data.error,
          // Some other informations
        })
      },
    },
  }
```

I didn't get the intention behind the makeError() call in the catch clause.