### PR TITLE
Add more HTTP verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ var {
   patch,
   delete    // don't destructure `delete` though, it's a keyword
   del,      // <- that's why we have this (del). or use `request.delete`
+  head,
+  options,
+  connect,
+  trace,
   mutate,   // GraphQL
   query,    // GraphQL
   abort

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,6 +309,10 @@ var {
   patch,
   delete  // don't destructure `delete` though, it's a keyword
   del,    // <- that's why we have this (del). or use `request.delete`
+  head,
+  options,
+  connect,
+  trace,
   mutate, // GraphQL
   query,  // GraphQL
   abort

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export enum HTTPMethod {
   PATCH = 'PATCH',
   POST = 'POST',
   PUT = 'PUT',
+  CONNECT = 'CONNECT',
+  TRACE = 'TRACE'
 }
 
 // https://www.apollographql.com/docs/react/api/react/hoc/#optionsfetchpolicy

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -208,6 +208,8 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     post,
     patch: makeFetch(HTTPMethod.PATCH),
     put: makeFetch(HTTPMethod.PUT),
+    options: makeFetch(HTTPMethod.OPTIONS),
+    head: makeFetch(HTTPMethod.HEAD),
     del,
     delete: del,
     abort: () => controller.current && controller.current.abort(),

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -210,6 +210,8 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     put: makeFetch(HTTPMethod.PUT),
     options: makeFetch(HTTPMethod.OPTIONS),
     head: makeFetch(HTTPMethod.HEAD),
+    connect: makeFetch(HTTPMethod.CONNECT),
+    trace: makeFetch(HTTPMethod.TRACE),
     del,
     delete: del,
     abort: () => controller.current && controller.current.abort(),


### PR DESCRIPTION
Closes #310

I've decided to implement my second proposal to allow `HEAD`, `OPTIONS`, `CONNECT` and `TRACE` calls and added `options`, `head`, `connect` and `trace` as fields of the request object.

I decided to explicitely omit the `method` field of the subtypes of `InitOptions` to prevent other to make the same mistake as me and assume I have control over the HTTP method by providing a value to this field... 😄 
**This is could potentally break existing TypeScript code!**