### PR TITLE
Fix " Cannot clone a disturbed Response"

### DIFF
--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -105,7 +105,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
         if (response.isCached && cachePolicy === CACHE_FIRST) {
           newRes = response.cached as Response
         } else {
-          newRes = await fetch(url, options)
+          newRes = (await fetch(url, options)).clone()
         }
         res.current = newRes.clone()
 


### PR DESCRIPTION
I'm using use-http and got a bug when testing on iOS 11 / iOS 10.3. 

![demo](https://user-images.githubusercontent.com/395137/112978660-e8de5800-9157-11eb-98fd-3fad0e587ead.png)
