### PR TITLE
resets retry attempts on abort

### DIFF
--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -836,22 +836,20 @@ describe('useFetch - BROWSER - retryOn & retryDelay', (): void => {
 
     it('should reset `attempts` when aborting', async (): Promise<void> => {
       jest.setTimeout(10000);
-      let fetchCalls = 0;
       
       const { result } = renderHook(
         () => {
           const fetchObj = useFetch('url-2', {
           retries: 5,
           async retryOn({ attempt }) {
-            fetchCalls = fetchCalls + 1
-            if(fetchCalls === 2) return false
+            if(fetch.mock.calls.length === 2) return false
             return true
           }
         })
 
         useEffect(() => {
-          if(fetchCalls === 2) fetchObj.abort()
-        }, [fetchCalls])
+          if(fetch.mock.calls.length === 2) fetchObj.abort()
+        }, [fetch.mock.calls.length])
 
         
         return fetchObj
@@ -861,8 +859,6 @@ describe('useFetch - BROWSER - retryOn & retryDelay', (): void => {
       await act(() => result.current.get())
       await act(() => result.current.get())
 
-      expect(fetchCalls).toEqual(2)
-      expect(result.current.error).toEqual(expectedError)
       expect(fetch.mock.calls.length).toBe(8) // intial get: 2, second: 1 + 5 retries
 
       jest.setTimeout(5000)

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -214,7 +214,10 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     trace: makeFetch(HTTPMethod.TRACE),
     del,
     delete: del,
-    abort: () => controller.current && controller.current.abort(),
+    abort: () => {
+      attempt.current = 0;
+      return controller.current && controller.current.abort();
+    },
     query: (query: any, variables: any) => post({ query, variables }),
     mutate: (mutation: any, variables: any) => post({ mutation, variables }),
     cache


### PR DESCRIPTION
Not sure if my use case is too narrow for this, but figured I'd put this up.

I was having trouble with combining a poll and `get`. Say I wanted 10 retries. If I aborted after 4, the next `get` would only retry 6 times, not the full 10. 