### PR TITLE
Do not refresh cache if the value was returned from the cache

### DIFF
--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -131,7 +131,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
           return theData
         }
 
-        if (cachePolicy === CACHE_FIRST) {
+        if (cachePolicy === CACHE_FIRST && !response.isCached) {
           await cache.set(response.id, newRes.clone())
         }
 


### PR DESCRIPTION
Fixes #294 

Simple fix purposed by @benarmston to avoid calling `cache.set` if the value was already returned from the cache