### PR TITLE
Fix slash added to extra parameters

### DIFF
--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -133,7 +133,7 @@ describe('useFetch - BROWSER - basic functionality', (): void => {
 })
 
 describe('useFetch - handling host/path/route parsing properly', (): void => {
-  it ('should have addSlash run properly', (): void => {
+  it('should have addSlash run properly', (): void => {
     expect(addSlash('', '')).toBe('')
     expect(addSlash('')).toBe('')
     expect(addSlash('?foo=bar', 'a.com')).toBe('?foo=bar')
@@ -145,6 +145,9 @@ describe('useFetch - handling host/path/route parsing properly', (): void => {
     expect(addSlash('foo', 'a.com/')).toBe('foo')
     expect(addSlash('foo')).toBe('/foo')
     expect(addSlash('/foo')).toBe('/foo')
+    expect(addSlash('bar', 'a.com?foo=')).toBe('bar')
+    expect(addSlash('&foo=bar', 'a.com?b=k')).toBe('&foo=bar')
+    expect(addSlash('&foo=bar')).toBe('&foo=bar')
   })
 })
 
@@ -159,7 +162,7 @@ describe('useFetch - responseType', (): void => {
     fetch.resetMocks()
     fetch.mockResponseOnce('Alex Cory')
     const { result, waitForNextUpdate } = renderHook(
-      () => useFetch('a-fake-url', { data: '', responseType: 'json' }, []), // onMount === true
+      () => useFetch('a-fake-url', { data: '', responseType: 'json' }, []) // onMount === true
     )
     expect(result.current.data).toEqual('')
     expect(result.current.loading).toBe(true)
@@ -174,7 +177,7 @@ describe('useFetch - responseType', (): void => {
     const expectedString = 'Alex Cory'
     fetch.mockResponseOnce(JSON.stringify(expectedString))
     const { result, waitForNextUpdate } = renderHook(
-      () => useFetch('a-fake-url', { data: '' }, []), // onMount === true
+      () => useFetch('a-fake-url', { data: '' }, []) // onMount === true
     )
     expect(result.current.data).toEqual('')
     expect(result.current.loading).toBe(true)
@@ -203,7 +206,7 @@ describe('useFetch - BROWSER - with <Provider />', (): void => {
     fetch.mockResponseOnce(JSON.stringify(expected))
   })
 
-  it(`should work correctly: useFetch({ data: [] }, [])`, async (): Promise<void> => {
+  it('should work correctly: useFetch({ data: [] }, [])', async (): Promise<void> => {
     const { result, waitForNextUpdate } = renderHook(
       () => useFetch({ data: {} }, []), // onMount === true
       { wrapper }
@@ -294,7 +297,7 @@ describe('useFetch - BROWSER - with <Provider />', (): void => {
     expect(fetch.mock.calls.length).toBe(2)
   })
 
-  it(`should execute GET using Provider url: useFetch('/people', [])`, async (): Promise<
+  it('should execute GET using Provider url: useFetch(\'/people\', [])', async (): Promise<
     void
   > => {
     const { result, waitForNextUpdate } = renderHook(
@@ -711,7 +714,7 @@ describe('useFetch - BROWSER - interceptors', (): void => {
             return response
           }
         }
-      }, []),
+      }, [])
     )
     await waitForNextUpdate()
     await act(result.current.get)
@@ -1138,7 +1141,7 @@ describe('useFetch - BROWSER - errors', (): void => {
   })
 
   it('should set the `error` with custom errors', async (): Promise<void> => {
-    const customError = { id: 'Custom Error'}
+    const customError = { id: 'Custom Error' }
     fetch.resetMocks()
     fetch.mockResponse(() => Promise.reject(customError))
     const { result } = renderHook(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,6 +262,8 @@ export const makeError = (name: string | number, message: string) => {
  * (path = '?foo=bar')                       => '?foo=bar'
  * (path = 'foo')                            => '/foo'
  * (path = '/foo')                           => '/foo'
+ * (path = '&foo=bar', url = 'a.com?b=k')    => '&foo=bar'
+ * (path = '&foo=bar')                       => '&foo=bar'
  */
 export const addSlash = (input?: string, url?: string) => {
   if (!input) return ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -266,10 +266,10 @@ export const makeError = (name: string | number, message: string) => {
 export const addSlash = (input?: string, url?: string) => {
   if (!input) return ''
   if (!url) {
-    if (input.startsWith('?') || input.startsWith('/')) return input
+    if (input.startsWith('?') || input.startsWith('&') || input.startsWith('/')) return input
     return `/${input}`
   }
   if (url.endsWith('/') && input.startsWith('/')) return input.substr(1)
-  if (!url.endsWith('/') && !input.startsWith('/') && !input.startsWith('?')) return `/${input}`
+  if (!url.endsWith('/') && !input.startsWith('/') && !input.startsWith('?') && !input.startsWith('&')) return `/${input}`
   return input
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,6 +255,7 @@ export const makeError = (name: string | number, message: string) => {
  * (path = '', url = '' || null | undefined) => ''
  * (path = '?foo=bar', url = 'a.com')        => '?foo=bar'
  * (path = '?foo=bar', url = 'a.com/')       => '?foo=bar'
+ * (path = 'bar', url = 'a.com/?foo=')       => 'bar'
  * (path = 'foo', url = 'a.com')             => '/foo'
  * (path = 'foo', url = 'a.com/')            => 'foo'
  * (path = '/foo', url = 'a.com')            => '/foo'
@@ -272,6 +273,6 @@ export const addSlash = (input?: string, url?: string) => {
     return `/${input}`
   }
   if (url.endsWith('/') && input.startsWith('/')) return input.substr(1)
-  if (!url.endsWith('/') && !input.startsWith('/') && !input.startsWith('?') && !input.startsWith('&')) return `/${input}`
+  if (!url.endsWith('/') && !input.startsWith('/') && !input.startsWith('?') && !input.startsWith('&') && !url.includes('?') ) return `/${input}`
   return input
 }


### PR DESCRIPTION
When checking the input to see if it contains URL parameters, the add slash function is not taking into account that we may already have URL parameters provided in the original URL.

If this is the case then the input will start with an ampersand, however the function was then incorrectly adding a `/` before the ampersand causing bad requests.